### PR TITLE
Added Docker-compose, compose build, and added data folder for chmod to prevent permission issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ example:
 ```sh
 git clone https://github.com/Goobaroo/docker-pixelmon.git
 sudo chmod -R 777 ./docker-pixelmon
-cd pixelmon
+cd docker-pixelmon
 
 sudo docker run -d \
   --restart unless-stopped \
@@ -63,19 +63,19 @@ sudo docker run -d \
   -e 'OPS'='' \
   -e 'MOTD'='Pixel Mon, Gotta PixelMon, DigiPoke.' \
   -p '25565:25565/tcp' \
-  -v 'data/':'/data':'rw' \
+  -v './data/':'/data':'rw' \
   'goobaroo/pixelmon:latest'
 ```
 ### Docker Compose Build
 ```sh
-git clone https://github.com/Goobaroo/docker-pixelmon.git ./pixelmon
+git clone https://github.com/Goobaroo/docker-pixelmon.git
 sudo chmod -R 777 ./docker-pixelmon
 cd docker-pixelmon
 sudo docker-compose -f docker-compose-build.yml up
 ```
 ### Docker Compose Pull
 ```sh
-git clone https://github.com/Goobaroo/docker-pixelmon.git ./pixelmon
+git clone https://github.com/Goobaroo/docker-pixelmon.git
 sudo chmod -R 777 ./docker-pixelmon
 cd docker-pixelmon
 sudo docker-compose up

--- a/README.md
+++ b/README.md
@@ -48,6 +48,39 @@ example:
 `OPS="OpPlayer1,OpPlayer2"`
 
 ## Troubleshooting
+### Ubuntu Docker Run
+```sh
+git clone https://github.com/Goobaroo/docker-pixelmon.git
+sudo chmod -R 777 ./docker-pixelmon
+cd pixelmon
+
+sudo docker run -d \
+  --restart unless-stopped \
+  --name 'minecraft-Pixelmon' \
+  --hostname 'minecraft-Pixelmon' \
+  -e 'EULA'='true' \
+  -e 'JVM_OPTS'='-Xms2048m -Xmx4096m' \
+  -e 'OPS'='' \
+  -e 'MOTD'='Pixel Mon, Gotta PixelMon, DigiPoke.' \
+  -p '25565:25565/tcp' \
+  -v 'data/':'/data':'rw' \
+  'goobaroo/pixelmon:latest'
+```
+### Docker Compose Build
+```sh
+git clone https://github.com/Goobaroo/docker-pixelmon.git ./pixelmon
+sudo chmod -R 777 ./docker-pixelmon
+cd docker-pixelmon
+sudo docker-compose -f docker-compose-build.yml up
+```
+### Docker Compose Pull
+```sh
+git clone https://github.com/Goobaroo/docker-pixelmon.git ./pixelmon
+sudo chmod -R 777 ./docker-pixelmon
+cd docker-pixelmon
+sudo docker-compose up
+```
+
 
 ### Accept the EULA
 Did you pass in the environment variable EULA set to `true`?

--- a/data/eula.txt.bak
+++ b/data/eula.txt.bak
@@ -1,0 +1,1 @@
+eula=true

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,20 @@
+services:
+  pixelmon:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: minecraft-Pixelmon
+    hostname: minecraft-Pixelmon
+    restart: unless-stopped
+    environment:
+      - EULA=true
+      - JVM_OPTS=-Xms2048m -Xmx4096m
+      - OPS=
+      - MOTD=Pixel Mon, Gotta PixelMon, DigiPoke.
+    ports:
+      - 25565:25565/tcp
+    volumes:
+      - ./data:/data:rw
+
+volumes:
+  data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  pixelmon:
+    image: goobaroo/pixelmon:latest
+    container_name: minecraft-Pixelmon
+    hostname: minecraft-Pixelmon
+    restart: unless-stopped
+    environment:
+      - EULA=true
+      - JVM_OPTS=-Xms2048m -Xmx4096m
+      - OPS=
+      - MOTD=Pixel Mon, Gotta PixelMon, DigiPoke.
+    ports:
+      - 25575:25565/tcp
+    volumes:
+      - ./data:/data:rw


### PR DESCRIPTION
I added readme instructions and created docker run / docker compose file / docker compose build file.

If the data folder is not pre-created the user just has to chmod or fix permissions elsewhere after they run the compose first to create data folder.